### PR TITLE
chore: increase default data frame maximum length to 1MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ if err != nil {
 
 By default, the library enforces the following limits:
 - Control frames: 4064 bytes
-- Data frames: 65536 bytes
+- Data frames: 1048576 bytes
 
 You can increase these limits to support vendors sending larger frames (like Infoblox):
 

--- a/framestream.go
+++ b/framestream.go
@@ -12,7 +12,7 @@ import (
 	"github.com/segmentio/kafka-go/compress"
 )
 
-const DefaultDataFrameMaxLength = 65536
+const DefaultDataFrameMaxLength = 1048576
 
 var ErrFrameTooLarge = errors.New("frame too large error")
 var ErrReaderNotReady = errors.New("reader not ready")


### PR DESCRIPTION
fix #23